### PR TITLE
ビルドに失敗する問題を修正

### DIFF
--- a/Packages/jp.iridescent.timemachine/Editor/TimeMachine.Editor.asmdef
+++ b/Packages/jp.iridescent.timemachine/Editor/TimeMachine.Editor.asmdef
@@ -6,7 +6,9 @@
         "GUID:02f771204943f4a40949438e873e3eff",
         "GUID:88c97f52b2a2a224a9fdf5a555e3f81b"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
## 概要
Editorのasmdefの設定が間違っていてビルドに失敗する問題を修正しました

## 変更内容
* EditorのasmdefはEditorのみで有効になるように変更
![image](https://github.com/murasaqi/Unity_TimeMachine/assets/40651807/6bd665b6-30ed-4485-b9a1-09ab3d82c70f)
