### PR TITLE
指定した名前のトラックのクリップと同じ配置のTimemachine clipを自動生成

### DIFF
--- a/jp.iridescent.timemachine/Editor/TimeMachineTrackEditor.cs
+++ b/jp.iridescent.timemachine/Editor/TimeMachineTrackEditor.cs
@@ -2,6 +2,8 @@
 #if  UNITY_EDITOR
 
 using UnityEditor;
+using UnityEditor.UIElements;
+using UnityEngine.Timeline;
 using UnityEngine.UIElements;
 
 namespace Iridescent.TimeMachine
@@ -35,13 +37,22 @@ namespace Iridescent.TimeMachine
             root.Add(targetTrackNameTextField);
 
             var createButton = new Button();
-            createButton.text = "Auto Create clips";
+            createButton.text = "Auto Create clips with Margin";
+            createButton.tooltip =
+                "Create clips with margin from target track. clip duration is (target clip duration - margin).";
             createButton.clicked += () =>
             {
-                track.CreateClipsAccordingTo(targetTrackNameTextField.value);
+                track.CreateClipsAccordingTo(targetTrackNameTextField.value, track.clipMargin);
             };
             root.Add(createButton);
             
+            // var alignButton = new Button();
+            // alignButton.text = "Align clips of target track";
+            // alignButton.clicked += () =>
+            // {
+            //     track.AlignTargetClips(targetTrackNameTextField.value);
+            // };
+            // root.Add(alignButton);
 
             var button = new Button();
             button.text = "Initialize clips";

--- a/jp.iridescent.timemachine/Editor/TimeMachineTrackEditor.cs
+++ b/jp.iridescent.timemachine/Editor/TimeMachineTrackEditor.cs
@@ -19,9 +19,6 @@ namespace Iridescent.TimeMachine
             // デフォルトのInspector表示を追加
             IMGUIContainer defaultInspector = new IMGUIContainer(() => DrawDefaultInspector());
             root.Add(defaultInspector);
-            
-            
-
 
             
             var layoutButton = new Button();
@@ -32,6 +29,18 @@ namespace Iridescent.TimeMachine
                 track.AutoLayoutClips(track.clipMargin);
             };
             root.Add(layoutButton);
+
+            var targetTrackNameTextField = new TextField();
+            targetTrackNameTextField.label = "Target Track Name";
+            root.Add(targetTrackNameTextField);
+
+            var createButton = new Button();
+            createButton.text = "Auto Create clips";
+            createButton.clicked += () =>
+            {
+                track.CreateClipsAccordingTo(targetTrackNameTextField.value);
+            };
+            root.Add(createButton);
             
 
             var button = new Button();

--- a/jp.iridescent.timemachine/Runtime/TimeMachineControlTrack.cs
+++ b/jp.iridescent.timemachine/Runtime/TimeMachineControlTrack.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -143,5 +143,40 @@ namespace Iridescent.TimeMachine
             if (mixer.GetBehaviour() != null) mixer.GetBehaviour().initialized = false;
         }
 
+        public void CreateClipsAccordingTo(string targetTrackName)
+        {
+            if(string.IsNullOrEmpty(targetTrackName)) return;
+
+            if (GetClips().Count() > 0)
+            {
+                Debug.LogError("Delete all clips before create new clips");
+            }
+
+            var tracks = this.timelineAsset.GetOutputTracks();
+            var targetTrack = tracks.FirstOrDefault(t => t.name == targetTrackName);
+            
+            if(targetTrack == null) return;
+
+            var targetClips = targetTrack?.GetClips();
+            int i = 0;
+            foreach (var tClip in targetClips)
+            {
+                var clip = this.CreateClip<TimeMachineControlClip>();
+                clip.start = tClip.start;
+                clip.duration = tClip.duration;
+                clip.displayName = tClip.displayName;
+                var tmClip = (TimeMachineControlClip)clip.asset;
+                tmClip.clipIndex = i;
+                tmClip.sectionName = clip.displayName;
+                tmClip.onClipEndAction = TimeMachineClipEvent.WAIT;
+                Debug.Log($"created : {tClip.displayName}");
+            }
+#if UNITY_EDITOR
+            // set dirty
+            UnityEditor.EditorUtility.SetDirty(timelineAsset);
+            // save assets
+            UnityEditor.AssetDatabase.SaveAssets();
+#endif
+        }
     }
 }

--- a/jp.iridescent.timemachine/Runtime/TimeMachineControlTrack.cs
+++ b/jp.iridescent.timemachine/Runtime/TimeMachineControlTrack.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
@@ -143,7 +142,7 @@ namespace Iridescent.TimeMachine
             if (mixer.GetBehaviour() != null) mixer.GetBehaviour().initialized = false;
         }
 
-        public void CreateClipsAccordingTo(string targetTrackName)
+        public void CreateClipsAccordingTo(string targetTrackName, double clipMargin)
         {
             if(string.IsNullOrEmpty(targetTrackName)) return;
 
@@ -154,16 +153,21 @@ namespace Iridescent.TimeMachine
 
             var tracks = this.timelineAsset.GetOutputTracks();
             var targetTrack = tracks.FirstOrDefault(t => t.name == targetTrackName);
-            
-            if(targetTrack == null) return;
+
+            if (targetTrack == null)
+            {
+                Debug.LogWarning("Target track not found");
+                return;
+            }
 
             var targetClips = targetTrack?.GetClips();
-            int i = 0;
-            foreach (var tClip in targetClips)
+            for (int i = 0; i < targetClips.Count(); i++)
             {
+                var tClip = targetClips.ElementAt(i);
                 var clip = this.CreateClip<TimeMachineControlClip>();
                 clip.start = tClip.start;
-                clip.duration = tClip.duration;
+                var d = tClip.duration - clipMargin;
+                clip.duration = d > 0 ? d : 0.1;
                 clip.displayName = tClip.displayName;
                 var tmClip = (TimeMachineControlClip)clip.asset;
                 tmClip.clipIndex = i;


### PR DESCRIPTION
- 参照の問題で名前はstringで与えるように。同じTimeline内のトラックを探す
- timemachineクリップ間のマージンを設定できるように。その際、対象クリップの長さからマージンを引くように実装。